### PR TITLE
Fix: Timestamp and calculation issues

### DIFF
--- a/nyc-turnstile-counts/import/import-csv.sh
+++ b/nyc-turnstile-counts/import/import-csv.sh
@@ -25,7 +25,7 @@ CREATE TABLE csv_$1 (
 INSERT INTO turnstile_observations
 SELECT * FROM (
   SELECT
-    DISTINCT CONCAT(controlarea, remoteunit, subunit_channel_position, TO_TIMESTAMP(EXTRACT(EPOCH FROM (date::date + time::time)))) AS id,
+    DISTINCT CONCAT(controlarea, remoteunit, subunit_channel_position, TO_TIMESTAMP(EXTRACT(EPOCH FROM (date || ' ' || time)::timestamp at time zone 'America/New_York'))) AS id,
     CONCAT(controlarea, remoteunit, subunit_channel_position) AS unit_id,
     controlarea,
     remoteunit,
@@ -33,7 +33,7 @@ SELECT * FROM (
     station,
     linenames,
     division,
-    TO_TIMESTAMP(EXTRACT(EPOCH FROM (date::date + time::time))) AS observed_at,
+    TO_TIMESTAMP(EXTRACT(EPOCH FROM (date || ' ' || time)::timestamp at time zone 'America/New_York')) AS observed_at,
     description,
     entries,
     exits,

--- a/nyc-turnstile-counts/sql/update-daily-subunit.sql
+++ b/nyc-turnstile-counts/sql/update-daily-subunit.sql
@@ -3,9 +3,9 @@ CREATE TABLE daily_subunit AS (
   SELECT
     unit_id,
     (array_agg(remoteunit))[1] AS remoteunit,
-    date_trunc('day', observed_at + interval '2h')::date AS date,
+    date_trunc('day', observed_at - interval '2h')::date AS date,
     SUM(net_entries) AS entries,
     SUM(net_exits) AS exits
   FROM turnstile_observations
-  GROUP BY unit_id, date_trunc('day', observed_at + interval '2h')
+  GROUP BY unit_id, date_trunc('day', observed_at - interval '2h')
 );

--- a/nyc-turnstile-counts/sql/update-net-values.sql
+++ b/nyc-turnstile-counts/sql/update-net-values.sql
@@ -3,14 +3,16 @@ WITH net_observations AS (
 SELECT
    id,
    entries - lag(entries, 1) OVER w AS calculated_net_entries,
-   exits - lag(exits, 1) OVER w AS calculated_net_exits
+   exits - lag(exits, 1) OVER w AS calculated_net_exits,
+   DATE_PART('day', observed_at - lag(observed_at, 1) OVER w) * 24 +
+              DATE_PART('hour', observed_at - lag(observed_at, 1) OVER w) as hours_difference
  FROM turnstile_observations
  WINDOW w AS (PARTITION BY unit_id ORDER BY observed_at)
 )
 UPDATE turnstile_observations
 SET
- net_entries = CASE WHEN abs(calculated_net_entries) < 10000 THEN abs(calculated_net_entries) END,
- net_exits = CASE WHEN abs(calculated_net_exits) < 10000 THEN abs(calculated_net_exits) END
+ net_entries = CASE WHEN abs(calculated_net_entries) < 10000 AND hours_difference <= 24 THEN abs(calculated_net_entries) END,
+ net_exits = CASE WHEN abs(calculated_net_exits) < 10000 AND hours_difference <= 24 THEN abs(calculated_net_exits) END
 FROM net_observations
 WHERE turnstile_observations.id = net_observations.id
 AND net_entries IS NULL;


### PR DESCRIPTION
I was trying to run this on my machine locally and was getting some very different data, so I investigated and found the following issues:

- When importing timestamps from MTA's CSVs, timestamps should be imported explicitly as Eastern Time (it defaulted to UTC for me)
- When attributing observations to the date, the calculation of day should be -2hrs instead of +2hrs
- Investigated on spikes in data and turns out some were related to subunits not reporting for days to return. We should throw away those observations.

Example on why JFK Jamaica had a spike on 2020-05-02:
![image](https://user-images.githubusercontent.com/3004927/87316592-f84b4180-c4f3-11ea-842f-e78d8bd786cb.png)
